### PR TITLE
feat: generate random terrain map

### DIFF
--- a/game/arena_game.py
+++ b/game/arena_game.py
@@ -1,5 +1,6 @@
 import pygame
 import random
+from game.map_generator import MapGenerator
 
 
 class AnimatedEntity:
@@ -78,11 +79,16 @@ class ArenaGame:
             self.screen = pygame.display.set_mode((self.WIDTH, self.HEIGHT))
             pygame.display.set_caption("Arena Survival")
             self.clock = pygame.time.Clock()
-
+            self.map_generator = MapGenerator(
+                self.WIDTH, self.HEIGHT, "./game/sprites/terrain"
+            )
+        else:
+            self.map_generator = None
         self.reset()
 
     def reset(self):
-
+        if self.map_generator:
+            self.map_generator.generate()
         enemy_anim_map = {
             "idletop": (0, 6), "idleleft": (1, 6), "idlebot": (2, 6), "idleright": (3, 6),
             "grabtop": (4, 6), "grableft": (5, 6), "grabbot": (6, 6), "grabright": (7, 6),
@@ -226,8 +232,9 @@ class ArenaGame:
 
         self.enemy.update_animation()
         self.player.update_animation()
-
         self.screen.fill((0, 0, 0))
+        if self.map_generator:
+            self.map_generator.render(self.screen)
         for obs in self.obstacles:
             obs.update_animation()
             obs.render(self.screen)

--- a/game/map_generator.py
+++ b/game/map_generator.py
@@ -1,0 +1,44 @@
+import os
+import random
+import pygame
+
+
+class MapGenerator:
+    """Generate a random isometric tile map used as background."""
+
+    def __init__(self, width: int, height: int, terrain_folder: str):
+        self.width = width
+        self.height = height
+        self.terrain_folder = terrain_folder
+        self.tiles = self._load_tiles()
+        if not self.tiles:
+            self.tile_width = 0
+            self.tile_height = 0
+        else:
+            self.tile_width = self.tiles[0].get_width()
+            self.tile_height = self.tiles[0].get_height()
+        self.map = []
+
+    def _load_tiles(self):
+        tiles = []
+        for name in os.listdir(self.terrain_folder):
+            if name.endswith(".png"):
+                path = os.path.join(self.terrain_folder, name)
+                image = pygame.image.load(path).convert_alpha()
+                tiles.append(image)
+        return tiles
+
+    def generate(self):
+        if not self.tiles:
+            self.map = []
+            return
+        cols = self.width // self.tile_width + 1
+        rows = self.height // self.tile_height + 1
+        self.map = [
+            [random.choice(self.tiles) for _ in range(cols)] for _ in range(rows)
+        ]
+
+    def render(self, surface):
+        for y, row in enumerate(self.map):
+            for x, tile in enumerate(row):
+                surface.blit(tile, (x * self.tile_width, y * self.tile_height))


### PR DESCRIPTION
## Summary
- load isometric terrain tiles into a new `MapGenerator` class
- plug map generation into `ArenaGame` and draw background terrain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689362c59984832a8786495ef087948d